### PR TITLE
Replace `rbxl` serialiser.

### DIFF
--- a/Source/assets/serialisers/csg/__init__.py
+++ b/Source/assets/serialisers/csg/__init__.py
@@ -21,6 +21,9 @@ hashSize: int = 0x10
 
 
 def createHash(data: bytes, saltIn: bytes = b'rfd') -> str:
+    '''
+    TODO: decide whether we should `jmp` this function in the EXEs or to actually use `createHash` and have the client validate the hash.
+    '''
     verticesSize: int = 0  # vertices.size() * sizeof(CSGVertex);
     indicesSize: int = 0  # indices.size() * sizeof(unsigned int);
     buffSize: int = verticesSize + indicesSize + saltSize

--- a/Source/assets/serialisers/rbxl/fonts.py
+++ b/Source/assets/serialisers/rbxl/fonts.py
@@ -83,22 +83,26 @@ def get_new_values(chunk_data: bytes) -> bytes:
     return bytes(new_values)
 
 
-def replace(parser: _logic.rbxl_parser, info: _logic.chunk_info) -> bytes | None:
-    old_prop_head = _logic.wrap_string(b'FontFace') + b'\x20'
-    new_prop_head = _logic.wrap_string(b'Font') + b'\x12'
-    if not info.chunk_data.startswith(old_prop_head, _logic.INT_SIZE):
+def replace(parser: _logic.rbxl_parser, chunk_data: _logic.chunk_data_type) -> bytes | None:
+    if not isinstance(chunk_data, _logic.chunk_data_type_prop):
         return None
 
-    class_id = info.chunk_data[0:_logic.INT_SIZE]
-    chunk_data = info.chunk_data[len(class_id + old_prop_head):]
-    new_values = get_new_values(chunk_data)
+    if chunk_data.prop_name != b'FontFace':
+        return None
+
+    if chunk_data.prop_type != 0x20:
+        return None
+
+    chunk_data.prop_name = b'Font'
+    chunk_data.prop_type = 0x12
 
     # Fonts (just like all enums) are stored as an INTERLEAVED array of big-endian `uint32`s.
     # Why the large string of zeroes?  We're taking advantage of the fact that `Enum.Font` never goes above 256.
     # Because integers here are big-endian, we put the least significant bytes at the end.
-    return b''.join([
-        class_id,
-        new_prop_head,
+    new_values = get_new_values(chunk_data.prop_values)
+    chunk_data.prop_values = b''.join([
         b'\x00' * len(new_values) * 3,
         new_values,
     ])
+
+    return chunk_data.to_bytes()

--- a/Source/assets/serialisers/rbxl/image_content.py
+++ b/Source/assets/serialisers/rbxl/image_content.py
@@ -15,23 +15,24 @@ def pad_enums(enums: list[int], uri_list: list[bytes]) -> list[bytes]:
     # ]
 
 
-def replace(parser: _logic.rbxl_parser, info: _logic.chunk_info) -> bytes | None:
+def replace(parser: _logic.rbxl_parser, chunk_data: _logic.chunk_data_type) -> bytes | None:
     '''
     https://github.com/rojo-rbx/rbx-dom/blob/5ee4d9062b2d31d61c07bd81e39b0260c6f91a0e/docs/binary.md#content
     '''
-    old_prop_head = _logic.wrap_string(b'ImageContent') + b'\x22'
-    new_prop_head = _logic.wrap_string(b'Image') + b'\x01'
-    if not info.chunk_data.startswith(old_prop_head, _logic.INT_SIZE):
+    if not isinstance(chunk_data, _logic.chunk_data_type_prop):
         return None
 
-    class_id = _logic.get_class_iden(info)
-    if class_id is None:
+    if chunk_data.prop_name != b'ImageContent':
         return None
 
-    prop_data = _logic.get_prop_values_bytes(info)
-    if prop_data is None:
-        return
-    enum_count = parser.class_dict[class_id].instance_count
+    if chunk_data.prop_type != 0x22:
+        return None
+
+    chunk_data.prop_name = b'Image'
+    chunk_data.prop_type = 0x01
+
+    prop_data = chunk_data.prop_values
+    enum_count = parser.class_dict[chunk_data.class_iden].instance_count
 
     # `SourceTypes` objects (just like all enums) are stored as an INTERLEAVED array of big-endian `uint32`s.
     # Why take just a partial segment?  We're taking advantage of the fact that `SourceTypes` never goes above 256.
@@ -51,9 +52,6 @@ def replace(parser: _logic.rbxl_parser, info: _logic.chunk_info) -> bytes | None
         limit=uri_count,
     )
     padded_uri_list = pad_enums(enums, uri_list)
+    chunk_data.prop_values = _logic.join_prop_strings(padded_uri_list)
 
-    return b''.join([
-        class_id,
-        new_prop_head,
-        _logic.join_prop_strings(padded_uri_list),
-    ])
+    return chunk_data.to_bytes()

--- a/Source/assets/serialisers/rbxl/roblox_links.py
+++ b/Source/assets/serialisers/rbxl/roblox_links.py
@@ -2,14 +2,14 @@ import re
 from . import _logic
 
 
-def replace(parser: _logic.rbxl_parser, info: _logic.chunk_info) -> bytes | None:
+def replace(parser: _logic.rbxl_parser, chunk_data: _logic.chunk_data_type) -> bytes | None:
     '''
     Redirects `assetdelivery.roblox.com` links within any `rbxm` data container to `rbxassetid://`.
     '''
-    prop_data = _logic.get_prop_values_bytes(info)
-    if prop_data is None:
-        return
-    if _logic.get_type_iden(info) != 0x01:
+    if not isinstance(chunk_data, _logic.chunk_data_type_prop):
+        return None
+
+    if chunk_data.prop_type != 0x01:
         return
 
     prop_values = _logic.split_prop_strings(prop_data)

--- a/Source/assets/serialisers/rbxl/script_disabled.py
+++ b/Source/assets/serialisers/rbxl/script_disabled.py
@@ -1,30 +1,23 @@
 from . import _logic
 
 
-def replace(parser: _logic.rbxl_parser, info: _logic.chunk_info) -> bytes | None:
-    if _logic.get_first_chunk_str(info) != b'Enabled':
+def replace(parser: _logic.rbxl_parser,  chunk_data: _logic.chunk_data_type) -> bytes | None:
+    if not isinstance(chunk_data, _logic.chunk_data_type_prop):
         return None
 
-    class_id = _logic.get_class_iden(info)
-    if class_id is None:
+    if chunk_data.prop_name != b'Enabled':
         return None
 
-    if not parser.class_dict[class_id].class_name.endswith(b'Script'):
+    class_iden = chunk_data.class_iden
+    if not parser.class_dict[class_iden].class_name.endswith(b'Script'):
         return None
 
-    class_id = info.chunk_data[0:_logic.INT_SIZE]
-    old_prop_name = b'\x07\x00\x00\x00Enabled\x02'
-    new_prop_name = b'\x08\x00\x00\x00Disabled\x02'
-    chunk_values = info.chunk_data[len(class_id + old_prop_name):]
-
-    new_values = bytes(
-        b ^ 1  # XORs booleaned uint8 between 0 and 1.
+    # Replace the enabled flag with its opposite.
+    # XORs booleaned uint8 between 0 and 1.
+    chunk_data.prop_values = bytes(
+        b ^ 1
         for b in
-        chunk_values
+        chunk_data.prop_values
     )
 
-    return b''.join([
-        class_id,
-        new_prop_name,
-        new_values,
-    ])
+    return chunk_data.to_bytes()

--- a/Source/assets/serialisers/rbxl/skip_bytecode.py
+++ b/Source/assets/serialisers/rbxl/skip_bytecode.py
@@ -1,17 +1,21 @@
 from . import _logic
 
 
-def replace(parser: _logic.rbxl_parser, info: _logic.chunk_info) -> bytes | None:
+def replace(parser: _logic.rbxl_parser, chunk_data: _logic.chunk_data_type) -> bytes | None:
     '''
     This function removes bytecode from any `rbxm` files.
     '''
-    prop_head = _logic.wrap_string(b'Source') + b'\x1D'
-    if not info.chunk_data.startswith(prop_head, _logic.INT_SIZE):
+    if not isinstance(chunk_data, _logic.chunk_data_type_prop):
         return None
 
-    prop_values_bytes = _logic.get_prop_values_bytes(info)
-    assert prop_values_bytes is not None
-    return b''.join([
-        prop_head,
-        _logic.join_prop_strings([b''] * len(prop_values_bytes)),
-    ])
+    if chunk_data.prop_name != b'Source':
+        return None
+
+    if chunk_data.prop_type != 0x1D:
+        return None
+
+    chunk_data.prop_values = _logic.join_prop_strings(
+        [b''] * len(chunk_data.prop_values)
+    )
+
+    return chunk_data.to_bytes()


### PR DESCRIPTION
As Rōblox's file-format standard deviates further from what it was in early 2021, more automated changes will need to be dome for each `rbxl` or `rbxm` file.

This pull request serves as a complete refactor for how RFD parses these files.