### PR TITLE
fix: typo inside of extractor.py

### DIFF
--- a/Source/assets/extractor.py
+++ b/Source/assets/extractor.py
@@ -69,7 +69,7 @@ def get_rōblox_cookie() -> str | None:
         (
             v for v in
             (
-                _get_cookie_from_system(),
+                get_cookie_from_system(),
                 os.environ.get('ROBLOSECURITY', None),
             )
             if test_cookie(v)


### PR DESCRIPTION
happened in https://github.com/Windows81/Roblox-Freedom-Distribution/commit/53c5c47ee746e81bca98ffebc459f9f77a1171ac when the function got renamed but its use hasnt