### PR TITLE
feat: add tool and asset thumbnail support

### DIFF
--- a/Source/assets/__init__.py
+++ b/Source/assets/__init__.py
@@ -110,6 +110,8 @@ class asseter:
     def resolve_asset_query(self, query: dict[str, str]) -> int | str | None:
         candidate_funcs = [
             (query.get('id'), self.resolve_asset_id),
+            (query.get('aid'), self.resolve_asset_id),
+            (query.get('AssetID'), self.resolve_asset_id),
             (query.get('assetversionid'), self.resolve_asset_version_id),
         ]
 

--- a/Source/assets/__init__.py
+++ b/Source/assets/__init__.py
@@ -10,7 +10,7 @@ import shutil
 
 # Internal or local application imports
 import util.const
-from . import material, queue, returns, serialisers, extractor
+from . import material, queue, returns, serialisers, extractor, thumbnail
 
 
 @dataclasses.dataclass
@@ -144,6 +144,8 @@ class asseter:
     def _load_asset_str(self, asset_id: str) -> bytes | None:
         if material.check(asset_id):
             return material.load_asset(asset_id)
+        if thumbnail.check(asset_id):
+            return thumbnail.load_asset(asset_id)
         return None
 
     def _load_redir_asset(self, asset_id: int | str, redirect: asset_redirect) -> returns.base_type:

--- a/Source/assets/const.py
+++ b/Source/assets/const.py
@@ -1,4 +1,5 @@
 ID_PREFIX = 'rbxmtl-'
+THUMB_PREFIX = 'rbxthmb-'
 
 MATERIAL_DICT_2014 = {
     'aluminum-diffuse.dds': 153465459,

--- a/Source/assets/thumbnail.py
+++ b/Source/assets/thumbnail.py
@@ -1,0 +1,34 @@
+from . import const, extractor
+import json
+
+def transform_to_id_num(asset_id: str) -> int:
+    asset_sub = asset_id[len(const.THUMB_PREFIX):-4] # strip .png
+
+    try:
+        return int(asset_sub)
+    except:
+        return 0
+
+def check(asset_id: str):
+    return asset_id.startswith(const.THUMB_PREFIX)
+
+def load_asset(asset_id: str) -> bytes | None:
+    id = transform_to_id_num(asset_id)
+    if id == 0:
+        return None
+
+    # technically we could also download the decal and parse its contents
+    # to extract the thumbnail, but that might be overkill
+    raw = extractor.download_item(
+        "https://thumbnails.roblox.com/v1/assets?assetids=%s&size=700x700&format=Png&isCircular=false" %
+        (id,)
+    )
+    if raw is None:
+        return None
+
+    parsed = json.loads(raw)
+
+    if "data" in parsed and len(parsed["data"]) != 1:
+        return None
+
+    return extractor.download_item(parsed["data"][0]['imageUrl'])

--- a/Source/web_server/endpoints/assets.py
+++ b/Source/web_server/endpoints/assets.py
@@ -60,9 +60,10 @@ def _(self: web_server_handler) -> bool:
     return True
 
 @server_path('/Game/Tools/ThumbnailAsset.ashx')
+@server_path('/Thumbs/Asset.ashx') # we can pass this too since we're calling rbx api regardless
 def _(self: web_server_handler) -> bool:
     asset_cache = self.game_config.asset_cache
-    asset_id = self.query["aid"]
+    asset_id = asset_cache.resolve_asset_query(self.query)
     if asset_id is None:
         self.send_error(404)
         return True

--- a/Source/web_server/endpoints/assets.py
+++ b/Source/web_server/endpoints/assets.py
@@ -1,6 +1,7 @@
 from web_server._logic import web_server_handler, server_path
 import assets.returns as returns
 import util.const
+import assets.const
 
 
 @server_path("/asset")
@@ -57,3 +58,27 @@ def _(self: web_server_handler) -> bool:
     '''
     self.send_json('true')
     return True
+
+@server_path('/Game/Tools/ThumbnailAsset.ashx')
+def _(self: web_server_handler) -> bool:
+    asset_cache = self.game_config.asset_cache
+    asset_id = self.query["aid"]
+    if asset_id is None:
+        self.send_error(404)
+        return True
+    
+    asset = asset_cache.get_asset(
+        f"{assets.const.THUMB_PREFIX}{asset_id}.png",
+        bypass_blocklist=self.is_privileged,
+    )
+
+    if isinstance(asset, returns.ret_data):
+        self.send_data(asset.data)
+        return True
+    elif isinstance(asset, returns.ret_none):
+        self.send_error(404)
+        return True
+    elif isinstance(asset, returns.ret_relocate):
+        self.send_redirect(asset.url)
+        return True
+    return False


### PR DESCRIPTION
this PR adds support for the `/Game/Tools/ThumbnailAsset.ashx` (used for tool decals/images) and `/Thumbs/Asset.ashx` (used sometimes in games prior to viewport frames to showcase models).

although we could manually fetch and dissect the decal rbxmx for the tools' decals, ive chosen to route those through the official api and let rōblox do it instead. those later on get saved under `rbxthmb-{ASSETID}.png`. And since they get routed through rōblox, ive decided to route the asset thumbnail api through it too.

this should fix older games (e.g. work at a pizza place 2014L) which still rely on decals. Though, due to it relying on the official api, the models may or may not have been modified/deleted with time, so asset replacement may still be required.