### PR TITLE
fix: persistence target not existing

### DIFF
--- a/Source/web_server/endpoints/persistence.py
+++ b/Source/web_server/endpoints/persistence.py
@@ -19,7 +19,7 @@ def _(self: web_server_handler) -> bool:
 
     scope = self.query.get('scope', 'global')
     data_type = self.query['type']
-    target = self.query['target']
+    target = self.query.get('target', 'null')
     key = self.query['key']
 
     value_str = form_data.get('value', 'null')


### PR DESCRIPTION
in v347, when a player leaves the server, rcc sometimes pings the persistence endpoint without any 'target' parameter.