### PR TITLE
fix: unset `animationAssetIds` to allow player-set animations

### DIFF
--- a/Source/web_server/endpoints/avatar.py
+++ b/Source/web_server/endpoints/avatar.py
@@ -78,12 +78,7 @@ def _(self: web_server_handler) -> bool:
             }
             for item in avatar.items
         ],
-        "animationAssetIds": {
-            "run": 2510238627,
-            "jump": 2510236649,
-            "fall": 2510233257,
-            "climb": 2510230574
-        },
+        "animationAssetIds": {},
         "bodyColors": {
             "headColorId": avatar.colors.head,
             "leftArmColorId": avatar.colors.left_arm,


### PR DESCRIPTION
quick hack to allow player specified r15 animations (walk, run, etc) by unsetting hardcoded asset ids. this allow users to edit their GameConfig.toml and specify the IDs of animations they wish to use (i.e: Stylish Run)
tested & working on 2018 and 2021. i only tested this very lightly but this single change shouldn't have any negative effects

not my discovery, but i can't remember who found it first

tested with the following accessory data:
```
retrieve_avatar_call_mode = "lua"
retrieve_avatar = '''
function(user_id_num, user_code)
    local default_avatar = {
        type = 'R15',
        items = {},
        scales = {
            height = 1,
            width = 1,
            head = 1,
            depth = 1,
            proportion = 0,
            body_type = 0,
        },
        colors = {
            head = BrickColor.Random().Number,
            left_arm = BrickColor.Random().Number,
            left_leg = BrickColor.Random().Number,
            right_arm = BrickColor.Random().Number,
            right_leg = BrickColor.Random().Number,
            torso = BrickColor.Random().Number,
        },
    }

    if user_code == 'Yuri' then
        default_avatar.items = {
			125157548394108,
            7581780596,
			4603805914,
			20573078,
			12413229126,
			619512153,
        }
        default_avatar.colors = {
            head = 148, 
            left_arm = 148,
            left_leg = 148,
            right_arm = 148,
            right_leg = 148,
            torso = 148,
        }
        default_avatar.scales = {
            height = 1,
            width = 1,
            head = 1,
            depth = 1,
            proportion = 0,
            body_type = 0, 
        }

    elseif user_code == 'Player2' then
        default_avatar.items = {
			12596168028,
            8262048015,
            7259172148,
            6471948627,
            6380112434,
            6238565077,
            6067201766,
            6067201270,
            4660621665,
            4466228735,
            6202647707,
            7317773,
        }
        default_avatar.colors = {
            head = 125, 
            left_arm = 125,
            left_leg = 125,
            right_arm = 125,
            right_leg = 125,
            torso = 125,
        }
        default_avatar.scales = {
            height = 1,
            width = 1,
            head = 1,
            depth = 1,
            proportion = 0,
            body_type = 0, 
        }
		
		elseif user_code == 'Yuri_alt' then
        default_avatar.items = {
			125157548394108,
            7581780596,
			4603805914,
			20573078,
			12413229126,
			619512153,
        }
        default_avatar.colors = {
            head = 125, 
            left_arm = 125,
            left_leg = 125,
            right_arm = 125,
            right_leg = 125,
            torso = 125,
        }
        default_avatar.scales = {
            height = 1,
            width = 1,
            head = 1,
            depth = 1,
            proportion = 0,
            body_type = 0, 
        }


    end
    return default_avatar
end
'''
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Character appearance endpoint now returns empty animation asset identifiers instead of previously hardcoded animation mappings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Windows81/Roblox-Freedom-Distribution/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->